### PR TITLE
DAQ-2866 Update pom path to match repository naming scheme

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 		<groupId>uk.ac.diamond</groupId>
 		<artifactId>uk.ac.diamond.aggregator</artifactId>
 		<version>1.0.0-SNAPSHOT</version>
-		<relativePath>../daq-aggregator</relativePath>
+		<relativePath>../daq-aggregator.git</relativePath>
 	</parent>
 
 	<modules>


### PR DESCRIPTION
Switch back to using the <repo-name>.git format for cloning
repositories. This is to support the many hard-coded paths existing in
the workspace and beyond.